### PR TITLE
Group build output by version in build.sh and Docker workflow

### DIFF
--- a/.github/workflows/bootstrap-on-docker.yml
+++ b/.github/workflows/bootstrap-on-docker.yml
@@ -17,4 +17,14 @@ jobs:
     - name: Build the Docker image
       run: docker build -t golang-compiler-bootstrap .
     - name: Build on docker
-      run: docker run golang-compiler-bootstrap bash -c "which go; cd /home/root && ./clone.sh && ./build.sh && ./version.sh"
+      run: |
+        docker run golang-compiler-bootstrap bash -c "
+          cd /home/root
+          echo '::group::clone'
+          ./clone.sh
+          echo '::endgroup::'
+          ./build.sh
+          echo '::group::version'
+          ./version.sh
+          echo '::endgroup::'
+        "

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,31 @@
 #!/bin/sh -e
 
 
+echo "::group::Build go1.4"
 (                                         cd go1.4/src     && ./make.bash )
+echo "::endgroup::"
+
+echo "::group::Build go1.17"
 (export GOROOT_BOOTSTRAP=$(pwd)/go1.4  && cd go1.17/src    && ./make.bash )
+echo "::endgroup::"
+
+echo "::group::Build go1.20"
 (export GOROOT_BOOTSTRAP=$(pwd)/go1.17 && cd go1.20/src    && ./make.bash )
+echo "::endgroup::"
+
+echo "::group::Build go1.22"
 (export GOROOT_BOOTSTRAP=$(pwd)/go1.20 && cd go1.22/src    && ./make.bash )
+echo "::endgroup::"
+
+echo "::group::Build go1.24"
 (export GOROOT_BOOTSTRAP=$(pwd)/go1.22 && cd go1.24/src    && ./make.bash )
+echo "::endgroup::"
+
+echo "::group::Build go1.26"
 (export GOROOT_BOOTSTRAP=$(pwd)/go1.24 && cd go1.26/src    && ./make.bash )
+echo "::endgroup::"
+
+echo "::group::Build go-latest"
 (export GOROOT_BOOTSTRAP=$(pwd)/go1.26 && cd go-latest/src && ./make.bash )
+echo "::endgroup::"
 


### PR DESCRIPTION
## Summary

- `build.sh`: 各バージョンのビルドを `::group::` / `::endgroup::` で折り畳み可能に
- `bootstrap-on-docker.yml`: `clone`, `version` の出力をグループ化。`build.sh` 内で各バージョンがグループ化されるため `::group::build` ラッパーは不要

## Test plan

- [x] GitHub Actions ログでバージョンごとのビルド出力が折り畳まれて表示されることを確認
- [x] `./build.sh` を引数なしで実行すると全バージョンがビルドされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)